### PR TITLE
Clean up logging and log key-values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6597,6 +6597,7 @@ dependencies = [
  "fern",
  "log",
  "objc",
+ "regex",
  "serde",
  "serde_json",
  "serde_repr",

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -26,6 +26,7 @@ log = { workspace = true, features = [ "kv_unstable" ] }
 time = { version = "0.3", features = [ "formatting", "local-offset" ] }
 fern = "0.6"
 thiserror = "1"
+regex = "1"
 
 [target."cfg(target_os = \"android\")".dependencies]
 android_logger = "0.14"

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -262,9 +262,7 @@ fn log(
     if !key_values.is_empty() {
         let kv_clean = serde_json::to_string_pretty(&kv)
             .unwrap()
-            .replace("\\", "")
-            .replace('\n', "")
-            .replace('\t', "");
+            .replace(["\\", '\n', '\t'], "");
         logger().log(
             &builder
                 .args(format_args!("{message} (Key Values: {})", kv_clean))

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -258,7 +258,21 @@ fn log(
     }
     builder.key_values(&kv);
 
-    logger().log(&builder.args(format_args!("{message}")).build());
+    // TODO: DRY this up. I tried. Rust is hard. Even for Claude.
+    if !key_values.is_empty() {
+        let kv_clean = serde_json::to_string_pretty(&kv)
+            .unwrap()
+            .replace("\\", "")
+            .replace('\n', "")
+            .replace('\t', "");
+        logger().log(
+            &builder
+                .args(format_args!("{message} (Key Values: {})", kv_clean))
+                .build(),
+        );
+    } else {
+        logger().log(&builder.args(format_args!("{message}")).build());
+    }
 }
 
 pub struct Builder {
@@ -267,6 +281,22 @@ pub struct Builder {
     timezone_strategy: TimezoneStrategy,
     max_file_size: u128,
     targets: Vec<Target>,
+}
+
+fn clean_target(target: &str) -> String {
+    // Cleans noise from the target to make it more readable; replaces
+    // /node_modules/.vite/deps and any URL host/port prefix.
+    // It also cleans the line/column number from @tauri-apps_plugin-log.js.
+    let target = regex::Regex::new(r"/node_modules/\.vite/deps")
+        .unwrap()
+        .replace_all(target, "/...");
+    let target = regex::Regex::new(r"https?://[^/]+/")
+        .unwrap()
+        .replace_all(&target, "...");
+    let target = regex::Regex::new(r"@tauri-apps_plugin-log\.js:\d+:\d+")
+        .unwrap()
+        .replace_all(&target, "@tauri-apps_plugin-log.js");
+    target.into_owned()
 }
 
 impl Default for Builder {
@@ -283,7 +313,7 @@ impl Default for Builder {
                 format_args!(
                     "{}[{}][{}] {}",
                     DEFAULT_TIMEZONE_STRATEGY.get_now().format(&format).unwrap(),
-                    record.target(),
+                    clean_target(record.target()),
                     record.level(),
                     message
                 ),


### PR DESCRIPTION
This PR changes the `log` plugin to:

- snip irrelevant node_modules javascript information out of log strings
- logs keyValues (details, or the second parameter of `@tauri-apps/plugin-log`'s `log`, `error`, etc functions) sent to Tauri